### PR TITLE
Fix duplicated emoji

### DIFF
--- a/src/services/Esa/HtmlHandler.php
+++ b/src/services/Esa/HtmlHandler.php
@@ -208,10 +208,12 @@ class HtmlHandler
         $html = $this->crawler->html();
 
         preg_match_all('/:(\w+):/', $html, $matches);
+        $names = $matches[1];
 
-        for ($i = 0; $i < count($matches[0]); $i++) {
-            $code = $matches[0][$i];
-            $replacement = sprintf('<img src="%s" class="emoji" title="%s" alt="%s">', $this->emojiManager->getImageUrl($matches[1][$i]), $code, $code);
+        for ($i = 0; $i < count($names); $i++) {
+            $name = $names[$i];
+            $code = ":${name}:";
+            $replacement = sprintf('<img src="%s" class="emoji" title="%s" alt="%s">', $this->emojiManager->getImageUrl($name), $code, $code);
 
             $html = str_replace($code, $replacement, $html);
         }

--- a/src/services/Esa/HtmlHandler.php
+++ b/src/services/Esa/HtmlHandler.php
@@ -210,6 +210,9 @@ class HtmlHandler
         preg_match_all('/:(\w+):/', $html, $matches);
         $names = $matches[1];
 
+        # remove duplicated occurrence
+        $names = array_values(array_unique($names));
+
         for ($i = 0; $i < count($names); $i++) {
             $name = $names[$i];
             $code = ":${name}:";

--- a/tests/services/Esa/HtmlHandlerTest.php
+++ b/tests/services/Esa/HtmlHandlerTest.php
@@ -234,6 +234,20 @@ class HtmlHandlerTest extends TestCase
         $this->SUT->replaceEmojiCodes();
     }
 
+    public function testReplaceDuplicatedEmojiCodes()
+    {
+        $code = 'emoji';
+        $imgTag = sprintf('<img src="%s" class="emoji" title=":%s:" alt=":%s:">', 'url', $code, $code);
+
+        $this->crawler->html()->willReturn(sprintf('<p>:%s::%s:</p>', $code, $code));
+        $this->crawler->clear()->shouldBeCalled();
+        $this->crawler->addHtmlContent(sprintf('<p>%s%s</p>', $imgTag, $imgTag))->shouldBeCalled();
+
+        $this->emojiManager->getImageUrl($code)->willReturn('url');
+
+        $this->SUT->replaceEmojiCodes();
+    }
+
     public function testReplaceHtml()
     {
         $this->crawler->html()->willReturn('html');


### PR DESCRIPTION
# Problem

When there are same emoji in a post, `img` tags are broken in esaba html document because of duplicated replacement.

# cf.
```
:esa: is a icon of :esa:
```

### current replacement
```
<img src="url_of_esa" class="emoji" title="<img src="url_of_esa" class="emoji" title="<img src="url_of_esa" class="emoji" title=":esa:" alt=":esa:">" alt=":esa:">" alt=":esa:"> is a icon of <img src="url_of_esa" class="emoji" title="<img src="url_of_esa" class="emoji" title="<img src="url_of_esa" class="emoji" title=":esa:" alt=":esa:">" alt=":esa:">" alt=":esa:">
```

### correct replacement

```
<img src="url_of_esa" class="emoji" title=":esa:" alt=":esa:"> is a icon of <img src="url_of_esa" class="emoji" title=":esa:" alt=":esa:">
```

# Original Repo PR

https://github.com/ttskch/esaba/pull/5