### PR TITLE
emoji URLが見つからなかった場合に、置き換えを行わずそのまま出力するようにする

### DIFF
--- a/src/services/Esa/HtmlHandler.php
+++ b/src/services/Esa/HtmlHandler.php
@@ -216,9 +216,13 @@ class HtmlHandler
         for ($i = 0; $i < count($names); $i++) {
             $name = $names[$i];
             $code = ":${name}:";
-            $replacement = sprintf('<img src="%s" class="emoji" title="%s" alt="%s">', $this->emojiManager->getImageUrl($name), $code, $code);
-
-            $html = str_replace($code, $replacement, $html);
+            try {
+                $replacement = sprintf('<img src="%s" class="emoji" title="%s" alt="%s">', $this->emojiManager->getImageUrl($name), $code, $code);
+                $html = str_replace($code, $replacement, $html);
+            } catch (\LogicException $e) {
+                // オリジナルemojiや誤検出の可能性があるので無視する
+                continue;
+            }
         }
 
         $this->initialize($html);

--- a/tests/services/Esa/HtmlHandlerTest.php
+++ b/tests/services/Esa/HtmlHandlerTest.php
@@ -248,6 +248,17 @@ class HtmlHandlerTest extends TestCase
         $this->SUT->replaceEmojiCodes();
     }
 
+    public function testInvalidEmojiCodes()
+    {
+        $this->crawler->html()->willReturn('<p>:invalid:</p>');
+        $this->crawler->clear()->shouldBeCalled();
+        $this->crawler->addHtmlContent('<p>:invalid:</p>')->shouldBeCalled();
+
+        $this->emojiManager->getImageUrl('invalid')->willThrow(new \LogicException());
+
+        $this->SUT->replaceEmojiCodes();
+    }
+
     public function testReplaceHtml()
     {
         $this->crawler->html()->willReturn('html');


### PR DESCRIPTION
# Problem

`2017/12/1 12:34:56` will cause an error because `:34:` emoji is not exists.