### PR TITLE
Enumerate posts under specific category

### DIFF
--- a/src/controllers.php
+++ b/src/controllers.php
@@ -63,6 +63,29 @@ $app->get('/post/{id}/', function (Request $request, $id) use ($app) {
 ->bind('post')
 ;
 
+$app->get('/path/', function (Request $request) use ($app) {
+    $path = $request->get('path', null);
+    $page = $request->get('page', 1);
+    $esa = $app['service.esa.proxy'];                   /** @var Proxy $esa */
+    $restrictor = $app['service.access_restrictor'];    /** @var AccessRestrictor $restrictor */
+    $result = $esa->getPosts(["q" => "in:$path", "page" => $page]);
+    $posts = array_filter($result["posts"], function($post) use ($restrictor) {
+      return $restrictor->isPublic($post['category'], $post['tags']);
+    });
+
+    $url_generator = $app['url_generator'];
+    return $app['twig']->render('posts.html.twig', [
+        'posts' => $posts,
+        'path' => $path,
+        'url_generator' => $url_generator,
+        'prev_page' => $result['prev_page'],
+        'next_page' => $result['next_page']
+    ]);
+})
+->bind('posts')
+;
+
+
 
 $app->post('/webhook/', function (Request $request) use ($app) {
 

--- a/src/services/Esa/Proxy.php
+++ b/src/services/Esa/Proxy.php
@@ -52,6 +52,14 @@ class Proxy
     }
 
     /**
+     * @param array $query
+     * @return array
+     */
+    public function getPosts($query) {
+        return $this->client->posts($query);
+    }
+
+    /**
      * @return array
      */
     public function getEmojis()

--- a/templates/posts.html.twig
+++ b/templates/posts.html.twig
@@ -1,0 +1,40 @@
+{% extends "layout.html.twig" %}
+{% block subtitle %}{{ path }}{% endblock %}
+
+{% block content %}
+    <h1>{{path}}</h1>
+
+    {% for post in posts %}
+        <div class="category">
+            {% for cat in post.category|split('/') %}
+                <span>{{ cat }}</span>
+                <span class="divider">/</span>
+            {% endfor %}
+        </div>
+        <div class="clearfix">
+            <h1 class="title {% if post.wip %}wip{% endif %}">
+                <span class="badge badge-pill badge-secondary mr-3 d-none">WIP</span>
+                <a href="{{url_generator.generate('post', { id: post.number })}}">
+                  {{- post.name -}}
+                </a>
+                <div class="d-inline ml-2">
+                    {%- for tag in post.tags -%}
+                        <span class="tag ml-2">#{{ tag }}</span>
+                    {%- endfor -%}
+                </div>
+            </h1>
+        </div>
+    {% endfor %}
+
+    {% if prev_page %}
+        <a href="{{url_generator.generate('posts', { path: path, page: prev_page})}}">
+            prev
+        </a>
+    {% endif %}
+
+    {% if next_page %}
+        <a href="{{url_generator.generate('posts', { path: path, page: next_page})}}">
+            next
+        </a>
+    {% endif %}
+{% endblock %}


### PR DESCRIPTION
Enumerate posts under the passed category.

## :camera: screenshots
<img width="906" alt="screen shot 2017-12-20 at 13 03 40" src="https://user-images.githubusercontent.com/9650/34208508-8bca39a2-e586-11e7-80b0-fbbe868204cd.png">

## URL style
`http://localhost:8888/path/?path=/Users/mzp`

Original esa url uses anchor(e.g. https://misoca.esa.io/#path=%2FUser), but it is hard to use at PHP. Anchor part of url is not sent to server. (see also [Get #part in URL with PHP/Symfony - Stack Overflow](https://stackoverflow.com/questions/2624119/get-part-in-url-with-php-symfony))