### PR TITLE
font size の単位を変更して npm install ができるようにした

### DIFF
--- a/assets/scss/_variables.scss
+++ b/assets/scss/_variables.scss
@@ -3,7 +3,7 @@
 // customize bootstrap
 $body-color: $gray-700;
 $text-muted: $gray-600;
-$font-size-base: 14px;
+$font-size-base: 1rem;
 
 // utilities
 $color-primary: map_get($theme-colors, 'primary');


### PR DESCRIPTION
DockerHub のビルドが失敗してる。
https://hub.docker.com/r/misoca/esaba/builds/bhxj9iwmtb9zvejjs9f5kbv/

ローカルで `docker build` を実行すると以下のようなエラーが発生することが確認できた。

```console
$ docker build -t esaba .
(snip)
Step 14/21 : RUN NODE_ENV=production npm run build
(snip)
ERROR in ./assets/scss/main.scss
Module build failed: ModuleBuildError: Module build failed:
    top: (($font-size-base * $line-height-base - $custom-control-indicator-size) / 2);
          ^
      Incompatible units: 'rem' and 'px'.
      in /app/node_modules/bootstrap/scss/_custom-forms.scss (line 66, column 12)
    at runLoaders (/app/node_modules/webpack/lib/NormalModule.js:195:19)
    at /app/node_modules/loader-runner/lib/LoaderRunner.js:364:11
    at /app/node_modules/loader-runner/lib/LoaderRunner.js:230:18
    at context.callback (/app/node_modules/loader-runner/lib/LoaderRunner.js:111:13)
    at Object.asyncSassJobQueue.push [as callback] (/app/node_modules/sass-loader/lib/loader.js:55:13)
    at Object.done [as callback] (/app/node_modules/neo-async/async.js:7974:18)
    at options.error (/app/node_modules/node-sass/lib/index.js:294:32)
 @ multi ./assets/js/main.js ./assets/scss/main.scss
```

`$font-size-base` の単位を `px` から `rem` に変更して解決した。

https://stackoverflow.com/questions/44769250/incompatible-units-rem-and-px-with-bootstrap-4-alpha-6