### PR TITLE
node 10.8 のイメージを使うようにする

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - .:/app
     working_dir: /app
   asset:
-    image: node:9.3-alpine
+    image: node:10.8-alpine
     command: sh -c "npm install && npm run watch"
     volumes:
           - .:/app


### PR DESCRIPTION
`docker-compose up`してもなかなか起動しなかった。https://hub.docker.com/_/node/ を見ると 9.3 の記述はなかった。更新したら、起動するようになった。