### PR TITLE
記事から絵文字を抽出する正規表現を変更する

### DIFF
--- a/src/services/Esa/HtmlHandler.php
+++ b/src/services/Esa/HtmlHandler.php
@@ -259,7 +259,7 @@ class HtmlHandler
     public function replaceEmojiCodes()
     {
         // find emoji codes.
-        preg_match_all('/:([^\s:<>\'"]+):/', $this->crawler->text(), $matches);
+        preg_match_all('/:([[:alnum:]_]+):/', $this->crawler->text(), $matches);
 
         $tempReplacements = [];
         foreach (array_unique($matches[1]) as $name) {


### PR DESCRIPTION
https://docs.esa.io/posts/226 では、「英数字と_がご利用いただけます。」と書いてある。ので、`/:([[:alnum:]_]+):/`で十分だと思った。

この変更で、[この記事](https://misoca.esa.io/posts/22267) が、閲覧できるようになる。原因は「:00〜10:」な表現を変換しようとしていたので。

あと、「URLのみの行が2行連続すると死ぬ」問題（https://misoca-inc.slack.com/archives/C3MLG07J7/p1534296935000100) も修正されるような気がします。